### PR TITLE
Fix: Correct bot type from Discord to Telegram

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-# Discord Bot Configuration
-DISCORD_TOKEN=your_discord_bot_token_here
+# Telegram Bot Configuration
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
 BOORU_API_KEY=your_booru_api_key_optional
 
 # Application Settings

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -1,6 +1,6 @@
-# Docker Configuration for Telbooru Discord Bot
+# Docker Configuration for Telbooru Telegram Bot
 
-This directory contains Docker configuration for running the Telbooru Discord bot in containerized environments.
+This directory contains Docker configuration for running the Telbooru Telegram bot in containerized environments.
 
 ## Quick Start
 
@@ -10,7 +10,7 @@ This directory contains Docker configuration for running the Telbooru Discord bo
 # Copy environment template
 cp .env.example .env
 
-# Edit .env file with your Discord token
+# Edit .env file with your Telegram bot token
 nano .env
 ```
 
@@ -43,7 +43,7 @@ docker-compose -f docker-compose.yml -f docker-compose.override.yml up -d
 ## Services
 
 ### telbooru-bot
-- **Description**: Main Discord bot service
+- **Description**: Main Telegram bot service
 - **Image**: Custom Python 3.11 image
 - **Environment**: Uses `.env` file
 - **Volumes**: 
@@ -63,7 +63,7 @@ docker-compose -f docker-compose.yml -f docker-compose.override.yml up -d
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `DISCORD_TOKEN` | Your Discord bot token | **Required** |
+| `TELEGRAM_BOT_TOKEN` | Your Telegram bot token | **Required** |
 | `BOORU_API_KEY` | Optional Booru API key | - |
 | `LOG_LEVEL` | Logging level | `INFO` |
 | `MAX_SEARCH_RESULTS` | Max images per search | `10` |
@@ -160,6 +160,15 @@ docker-compose down
    ```bash
    # Check Redis status
    docker-compose exec redis redis-cli ping
+   ```
+
+4. **Telegram Bot Not Responding**
+   ```bash
+   # Check bot logs
+   docker-compose logs -f telbooru-bot
+   
+   # Verify token is set
+   docker-compose exec telbooru-bot env | grep TELEGRAM
    ```
 
 ### Debug Mode

--- a/DOCKER_SUMMARY.md
+++ b/DOCKER_SUMMARY.md
@@ -17,7 +17,7 @@
 ### Services Configured
 
 #### Core Services
-- **telbooru-bot**: Main Discord bot service
+- **telbooru-bot**: Main Telegram bot service
 - **redis**: In-memory cache and session storage
 
 ### Features
@@ -65,7 +65,7 @@ make status       # Check service status
 1. **Setup Environment**
    ```bash
    cp .env.example .env
-   # Edit .env with your Discord token
+   # Edit .env with your Telegram bot token
    ```
 
 2. **Development**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Telbooru Discord Bot Dockerfile
+# Telbooru Telegram Bot Dockerfile
 FROM python:3.11-slim as base
 
 # Set environment variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: telbooru-bot
     restart: unless-stopped
     environment:
-      - DISCORD_TOKEN=${DISCORD_TOKEN}
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
       - BOORU_API_KEY=${BOORU_API_KEY:-}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - MAX_SEARCH_RESULTS=${MAX_SEARCH_RESULTS:-10}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-# Discord Bot
-discord.py>=2.3.0
-discord-py-interactions>=5.10.0
+# Telegram Bot
+python-telegram-bot>=20.0
 
 # HTTP Client
 aiohttp>=3.8.0


### PR DESCRIPTION
- Updated all references from Discord to Telegram
- Changed DISCORD_TOKEN to TELEGRAM_BOT_TOKEN
- Updated requirements.txt with correct Telegram bot library
- Fixed documentation to reflect Telegram bot usage